### PR TITLE
Health: make test_connection robust to DictCursor key casing

### DIFF
--- a/src/igloo_mcp/mcp/tools/health.py
+++ b/src/igloo_mcp/mcp/tools/health.py
@@ -174,15 +174,16 @@ class HealthCheckTool(MCPTool):
             cursor.execute("SELECT CURRENT_ROLE() as role")
             role_result = cursor.fetchone()
 
+            def _pick(d: Dict[str, Any] | None, lower: str, upper: str) -> Any:
+                if not isinstance(d, dict):
+                    return None
+                return d.get(lower) if lower in d else d.get(upper)
+
             return {
-                "warehouse": (
-                    warehouse_result.get("warehouse") if warehouse_result else None
-                ),
-                "database": (
-                    database_result.get("database") if database_result else None
-                ),
-                "schema": schema_result.get("schema") if schema_result else None,
-                "role": role_result.get("role") if role_result else None,
+                "warehouse": _pick(warehouse_result, "warehouse", "WAREHOUSE"),
+                "database": _pick(database_result, "database", "DATABASE"),
+                "schema": _pick(schema_result, "schema", "SCHEMA"),
+                "role": _pick(role_result, "role", "ROLE"),
             }
 
     async def _check_profile(self) -> Dict[str, Any]:

--- a/tests/test_health_connection_casing.py
+++ b/tests/test_health_connection_casing.py
@@ -1,0 +1,65 @@
+"""Casing behavior test for HealthCheckTool connection info.
+
+Ensures that DictCursor results with UPPERCASE keys are handled.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from igloo_mcp.config import Config
+from igloo_mcp.mcp.tools.health import HealthCheckTool
+
+
+class _UpperDictCursor:
+    def __init__(self) -> None:
+        self._current: Dict[str, Any] = {}
+
+    def execute(self, query: str) -> None:
+        # Emulate UPPERCASE column labels typically seen with DictCursor
+        key = query.split("CURRENT_", 1)[-1].split("()")[0]
+        label = key.split()[0]  # strip potential "as ..." suffix
+        self._current = {label: label}
+
+    def fetchone(self) -> Dict[str, Any]:
+        return self._current
+
+
+class _Conn:
+    def __init__(self, cursor: _UpperDictCursor) -> None:
+        self.cursor = cursor
+
+    def __enter__(self) -> tuple[None, _UpperDictCursor]:
+        return None, self.cursor
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - simple stub
+        return False
+
+
+class _Svc:
+    def __init__(self) -> None:
+        self._cursor = _UpperDictCursor()
+
+    def get_query_tag_param(self) -> Dict[str, Any]:
+        return {}
+
+    def get_connection(self, **kwargs: Any) -> _Conn:  # noqa: ANN401
+        return _Conn(self._cursor)
+
+
+@pytest.mark.asyncio
+async def test_health_connection_handles_uppercase_keys() -> None:
+    config = Config.from_env()
+    tool = HealthCheckTool(config=config, snowflake_service=_Svc())
+
+    result = await tool.execute()
+
+    conn = result["connection"]
+    # Values should not be None when uppercase keys are returned
+    assert conn["connected"] is True
+    assert conn["warehouse"] is not None
+    assert conn["database"] is not None
+    assert conn["schema"] is not None
+    assert conn["role"] is not None


### PR DESCRIPTION
Fixes #25

## Summary
Ensure `test_connection` correctly reports session context by tolerating DictCursor key casing. Previously, `warehouse`, `database`, `schema`, and `role` could show as `null` due to uppercase column-label keys.

## Context
- DictCursor returns keys in UPPERCASE for column labels, while the code read lowercase keys.
- Issue: https://github.com/Evan-Kim2028/igloo-mcp/issues/25

## Implementation
- Make key access case-tolerant when reading CURRENT_* values:
  - `src/igloo_mcp/mcp/tools/health.py`
- Add focused test to validate uppercase DictCursor behavior:
  - `tests/test_health_connection_casing.py`

## Test Plan
- Unit test covers case where DictCursor yields UPPERCASE keys:
  - `pytest -q tests/test_health_connection_casing.py`
- Note: Nulls remain expected when the session truly lacks active context.

## Impact & Risk
- Backward compatible; no API changes.
- Low risk; internal key-access logic only.

## Checklist
- [x] References the issue (auto-closes via "Fixes #25")
- [x] Clear summary and context
- [x] Includes a unit test
- [x] No breaking changes
- [ ] Docs not required (behavior correction only)
