### PR TITLE
Bundle reporting + query tooling (codex plan)

### DIFF
--- a/examples/reports/flash_crash_report.yaml
+++ b/examples/reports/flash_crash_report.yaml
@@ -1,0 +1,18 @@
+id: "flash-crash-oct-10"
+title: "Oct-10 Flash Crash Report (example)"
+version: "0.1.0"
+author: "example-analyst"
+templates:
+  main: "templates/flash_crash_report.md.jinja"
+  engine: "jinja"
+datasets:
+  - name: "flash_crash_events"
+    description: "Example dataset bound to a fictitious execution"
+    source:
+      execution_id: "example-execution-id"
+      sql_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+    tags: ["example", "demo"]
+outputs:
+  - name: "default"
+    format: "markdown"
+    path: "reports/flash_crash_report.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,14 @@ dependencies = [
     "fastmcp>=2.8.1",
     "snowflake-labs-mcp>=1.3.3",
     "pydantic>=2.7.0",
+    "jinja2>=3.1.0",
 ]
 
 # MCP dependencies are included by default - no separate installation needed
 
 [project.scripts]
 igloo-mcp = "igloo_mcp.mcp_server:main"
+igloo-report = "igloo_mcp.report_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/Evan-Kim2028/igloo-mcp"

--- a/src/igloo_mcp/mcp_server.py
+++ b/src/igloo_mcp/mcp_server.py
@@ -14,6 +14,7 @@ import argparse
 import os
 import string
 from contextlib import asynccontextmanager
+from dataclasses import asdict
 from functools import partial
 from typing import Any, Dict, List, Optional
 
@@ -62,11 +63,21 @@ from .mcp_health import (
     MCPHealthMonitor,
 )
 from .mcp_resources import MCPResourceManager
-from .path_utils import resolve_artifact_root
+from .path_utils import find_repo_root, resolve_artifact_root, resolve_history_path
 from .profile_utils import (
     ProfileValidationError,
     get_profile_summary,
     validate_and_resolve_profile,
+)
+from .reporting.builder import build_report, lint_report
+from .reporting.history_index import HistoryIndex
+from .reporting.manifest import (
+    DatasetRef,
+    DatasetSource,
+    ReportManifest,
+    ReportOutput,
+    TemplatesConfig,
+    load_manifest,
 )
 from .service_layer import CatalogService, DependencyService, QueryService
 from .session_utils import (
@@ -540,6 +551,288 @@ def register_igloo_mcp(
             column_contains=column_contains,
             limit=limit,
         )
+
+    @server.tool(
+        name="report_scaffold",
+        description="Create a skeleton report manifest from recent execute_query history",
+    )
+    async def report_scaffold_tool(
+        manifest_path: Annotated[
+            Optional[str],
+            Field(
+                description=(
+                    "Optional path where a manifest YAML would live; used for id and "
+                    "default output naming when write_manifest is true. Relative paths "
+                    "are resolved against the repository root."
+                ),
+                default=None,
+            ),
+        ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                description=(
+                    "Number of recent history entries to scaffold into datasets"
+                ),
+                ge=1,
+                le=20,
+                default=3,
+            ),
+        ] = 3,
+        write_manifest: Annotated[
+            bool,
+            Field(
+                description=(
+                    "If true, write the scaffolded manifest to manifest_path (or "
+                    "'report.yaml' in the repo root when manifest_path is omitted) and "
+                    "return the resolved path. When false, only return manifest JSON."
+                ),
+                default=False,
+            ),
+        ] = False,
+    ) -> Dict[str, Any]:
+        """Scaffold a ReportManifest from recent history entries.
+
+        This tool is intended for AI/native workflows: it returns the manifest as
+        structured JSON so agents can edit and commit it, and optionally writes a
+        YAML file when requested.
+        """
+
+        from pathlib import Path
+
+        history_path = resolve_history_path()
+        index = HistoryIndex(history_path)
+        records = index.records
+        records_sorted = sorted(records, key=lambda r: r.get("ts") or 0.0)
+        recent = records_sorted[-limit:] if limit and records_sorted else []
+
+        datasets: List[DatasetRef] = []
+        for idx, record in enumerate(recent, start=1):
+            exec_id = record.get("execution_id")
+            sha = record.get("sql_sha256")
+            artifacts = record.get("artifacts") or {}
+            cache_manifest = artifacts.get("cache_manifest") or record.get(
+                "cache_manifest"
+            )
+            source = DatasetSource(
+                execution_id=str(exec_id) if exec_id else None,
+                sql_sha256=str(sha) if sha else None,
+                cache_manifest=str(cache_manifest) if cache_manifest else None,
+            )
+            description = None
+            if record.get("reason"):
+                description = str(record["reason"])
+            datasets.append(
+                DatasetRef(
+                    name=f"dataset_{idx}",
+                    description=description,
+                    source=source,
+                )
+            )
+
+        if manifest_path is not None:
+            manifest_raw = Path(manifest_path)
+            report_id = manifest_raw.stem or "report"
+        else:
+            report_id = "report"
+
+        manifest = ReportManifest(
+            id=report_id,
+            title=f"Report {report_id}",
+            templates=TemplatesConfig(main="templates/report.md"),
+            datasets=datasets,
+            outputs=[
+                ReportOutput(
+                    name="default",
+                    format="markdown",
+                    path=f"reports/{report_id}.md",
+                )
+            ],
+        )
+
+        written_path: Optional[str] = None
+        if write_manifest:
+            raw_path = manifest_path or "report.yaml"
+            path = Path(raw_path).expanduser()
+            if not path.is_absolute():
+                repo_root = find_repo_root()
+                path = (repo_root / path).resolve()
+
+            path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                import yaml  # type: ignore[import-untyped]
+
+                with path.open("w", encoding="utf-8") as fh:
+                    yaml.safe_dump(manifest.model_dump(), fh, sort_keys=False)
+                written_path = str(path)
+            except Exception as exc:  # pragma: no cover - unlikely I/O error
+                raise RuntimeError(
+                    f"Failed to write scaffolded manifest: {exc}"
+                ) from exc
+
+        return {
+            "manifest": manifest.model_dump(),
+            "report_id": manifest.id,
+            "dataset_count": len(manifest.datasets),
+            "history_path": str(history_path),
+            "written_path": written_path,
+        }
+
+    @server.tool(
+        name="report_lint",
+        description="Validate a report manifest and its dataset bindings",
+    )
+    async def report_lint_tool(
+        manifest_path: Annotated[
+            str,
+            Field(
+                description=(
+                    "Path to report manifest YAML (relative to repo root or absolute)."
+                ),
+                default="report.yaml",
+            ),
+        ] = "report.yaml",
+    ) -> Dict[str, Any]:
+        from pathlib import Path
+
+        raw_path = Path(manifest_path).expanduser()
+        if raw_path.is_absolute():
+            manifest_abs = raw_path.resolve()
+        else:
+            repo_root = find_repo_root()
+            manifest_abs = (repo_root / raw_path).resolve()
+
+        issues = lint_report(manifest_abs)
+        return {
+            "manifest_path": str(manifest_abs),
+            "ok": not issues,
+            "issues": [asdict(issue) for issue in issues],
+        }
+
+    @server.tool(
+        name="report_build",
+        description="Render a report manifest into an output body with provenance metadata",
+    )
+    async def report_build_tool(
+        manifest_path: Annotated[
+            str,
+            Field(
+                description=(
+                    "Path to report manifest YAML (relative to repo root or absolute)."
+                ),
+                default="report.yaml",
+            ),
+        ] = "report.yaml",
+        output_name: Annotated[
+            Optional[str],
+            Field(
+                description=(
+                    "Named output from manifest.outputs to build (default: first output)."
+                ),
+                default=None,
+            ),
+        ] = None,
+        format: Annotated[
+            Optional[str],
+            Field(
+                description=(
+                    "Optional override for output format: 'markdown', 'html', or 'json'. "
+                    "Defaults to the manifest output format."
+                ),
+                default=None,
+            ),
+        ] = None,
+        persist_output: Annotated[
+            bool,
+            Field(
+                description=(
+                    "If true, write the rendered body to disk using either output_path "
+                    "or manifest.outputs[].path."
+                ),
+                default=False,
+            ),
+        ] = False,
+        output_path: Annotated[
+            Optional[str],
+            Field(
+                description=(
+                    "Explicit output path when persist_output is true (relative to repo "
+                    "root or absolute)."
+                ),
+                default=None,
+            ),
+        ] = None,
+    ) -> Dict[str, Any]:
+        import json
+        from pathlib import Path
+
+        raw_path = Path(manifest_path).expanduser()
+        if raw_path.is_absolute():
+            manifest_abs = raw_path.resolve()
+        else:
+            repo_root = find_repo_root()
+            manifest_abs = (repo_root / raw_path).resolve()
+
+        result = build_report(manifest_abs, output_name=output_name, refresh=False)
+        result_format = result.get("format", "markdown")
+        body = result.get("body", "")
+        provenance = result.get("provenance", {})
+
+        effective_format = format or result_format
+        if effective_format == "html" and result_format == "markdown":
+            body = f"<html><body><pre>\n{body}\n</pre></body></html>\n"
+
+        selected_output_name: Optional[str] = output_name
+        written_path: Optional[str] = None
+
+        if persist_output:
+            if output_path is not None:
+                out_path = Path(output_path).expanduser()
+                if not out_path.is_absolute():
+                    repo_root = find_repo_root()
+                    out_path = (repo_root / out_path).resolve()
+            else:
+                manifest_obj = load_manifest(manifest_abs)
+                selected = None
+                if output_name is not None:
+                    for candidate in manifest_obj.outputs:
+                        if candidate.name == output_name:
+                            selected = candidate
+                            break
+                if selected is None:
+                    if not manifest_obj.outputs:
+                        raise ValueError(
+                            "Report manifest defines no outputs and output_path was not provided",
+                        )
+                    selected = manifest_obj.outputs[0]
+                selected_output_name = selected.name
+                out_path = Path(selected.path).expanduser()
+                if not out_path.is_absolute():
+                    repo_root = find_repo_root()
+                    out_path = (repo_root / out_path).resolve()
+
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(body, encoding="utf-8")
+            written_path = str(out_path)
+
+        response: Dict[str, Any] = {
+            "manifest_path": str(manifest_abs),
+            "output_name": selected_output_name,
+            "format": effective_format,
+            "body": body,
+            "provenance": provenance,
+        }
+
+        if effective_format == "json" and result_format == "json":
+            try:
+                response["body_json"] = json.loads(body)
+            except Exception:
+                pass
+
+        if written_path is not None:
+            response["output_path"] = written_path
+
+        return response
 
     @server.tool(
         name="record_query_insight",

--- a/src/igloo_mcp/report_cli.py
+++ b/src/igloo_mcp/report_cli.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import yaml  # type: ignore[import-untyped]
+
+from .path_utils import find_repo_root, resolve_history_path
+from .reporting.builder import LintIssue, build_report, lint_report
+from .reporting.history_index import HistoryIndex
+from .reporting.manifest import (
+    DatasetRef,
+    DatasetSource,
+    ReportManifest,
+    ReportOutput,
+    TemplatesConfig,
+)
+
+
+def _resolve_manifest_path(raw: str) -> Path:
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return path
+    repo_root = find_repo_root()
+    return (repo_root / path).resolve()
+
+
+def _command_build(args: argparse.Namespace) -> int:
+    manifest_path = _resolve_manifest_path(args.manifest)
+
+    try:
+        result = build_report(
+            manifest_path,
+            output_name=args.output_name,
+            refresh=args.refresh,
+        )
+    except Exception as exc:  # pragma: no cover - error surface
+        print(f"report build failed: {exc}", file=sys.stderr)
+        return 1
+
+    body = result.get("body", "")
+    fmt = result.get("format", "markdown")
+
+    # Optional format override (html simply wraps markdown)
+    effective_format = args.format or fmt
+    if effective_format == "html" and fmt == "markdown":
+        body = f"<html><body><pre>\n{body}\n</pre></body></html>\n"
+
+    # Determine output path: explicit flag wins; otherwise use manifest outputs
+    output_path: Path
+    if args.output:
+        output_path = _resolve_manifest_path(args.output)
+    else:
+        # Re-load manifest cheaply to get output metadata
+        from .reporting.manifest import load_manifest
+
+        manifest = load_manifest(manifest_path)
+        selected = None
+        if args.output_name is not None:
+            for candidate in manifest.outputs:
+                if candidate.name == args.output_name:
+                    selected = candidate
+                    break
+        if selected is None:
+            if not manifest.outputs:
+                print(
+                    "report build: manifest defines no outputs and --output was not provided",
+                    file=sys.stderr,
+                )
+                return 1
+            selected = manifest.outputs[0]
+        output_path = _resolve_manifest_path(selected.path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(body, encoding="utf-8")
+    print(f"Wrote report to {output_path} ({effective_format})")
+    return 0
+
+
+def _command_lint(args: argparse.Namespace) -> int:
+    manifest_path = _resolve_manifest_path(args.manifest)
+    issues: List[LintIssue] = lint_report(manifest_path)
+    if not issues:
+        print("Manifest lint passed: no issues found")
+        return 0
+    for issue in issues:
+        prefix = issue.code
+        if issue.dataset_name:
+            prefix += f"[{issue.dataset_name}]"
+        print(f"{prefix}: {issue.message}", file=sys.stderr)
+        if issue.detail:
+            print(f"  detail: {issue.detail}", file=sys.stderr)
+    return 1
+
+
+def _command_scaffold(args: argparse.Namespace) -> int:
+    manifest_path = _resolve_manifest_path(args.manifest)
+    repo_root = find_repo_root()
+
+    try:
+        history_path = resolve_history_path()
+    except Exception as exc:  # pragma: no cover - rare
+        print(f"Failed to resolve history path: {exc}", file=sys.stderr)
+        return 1
+
+    index = HistoryIndex(history_path)
+    records = index.records
+    # Use the latest few entries to seed datasets
+    records_sorted = sorted(records, key=lambda r: r.get("ts") or 0.0)
+    recent = records_sorted[-args.limit :] if args.limit and records_sorted else []
+
+    datasets: List[DatasetRef] = []
+    for idx, record in enumerate(recent, start=1):
+        exec_id = record.get("execution_id")
+        sha = record.get("sql_sha256")
+        artifacts = record.get("artifacts") or {}
+        cache_manifest = artifacts.get("cache_manifest") or record.get("cache_manifest")
+        source = DatasetSource(
+            execution_id=str(exec_id) if exec_id else None,
+            sql_sha256=str(sha) if sha else None,
+            cache_manifest=str(cache_manifest) if cache_manifest else None,
+        )
+        description = None
+        if record.get("reason"):
+            description = str(record["reason"])
+        datasets.append(
+            DatasetRef(
+                name=f"dataset_{idx}",
+                description=description,
+                source=source,
+            )
+        )
+
+    report_id = manifest_path.stem or "report"
+    manifest = ReportManifest(
+        id=report_id,
+        title=f"Report {report_id}",
+        templates=TemplatesConfig(main="templates/report.md"),
+        datasets=datasets,
+        outputs=[
+            ReportOutput(
+                name="default",
+                format="markdown",
+                path=f"reports/{report_id}.md",
+            )
+        ],
+    )
+
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with manifest_path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(manifest.model_dump(), fh, sort_keys=False)
+
+    rel_path = manifest_path
+    try:
+        rel_path = manifest_path.relative_to(repo_root)
+    except Exception:
+        pass
+    print(f"Scaffolded manifest at {rel_path}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Manifest-driven reporting utilities for igloo-mcp",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Render a report manifest into an output file",
+    )
+    build_parser.add_argument(
+        "--manifest",
+        default="report.yaml",
+        help="Path to report manifest (default: report.yaml)",
+    )
+    build_parser.add_argument(
+        "--output",
+        default=None,
+        help="Explicit output path (overrides manifest.outputs)",
+    )
+    build_parser.add_argument(
+        "--output-name",
+        default=None,
+        help="Named output from manifest.outputs to build",
+    )
+    build_parser.add_argument(
+        "--format",
+        choices=["markdown", "html", "json"],
+        default=None,
+        help="Override output format (html wraps markdown)",
+    )
+    build_parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Reserved flag; currently ignored (no re-execution)",
+    )
+    build_parser.set_defaults(func=_command_build)
+
+    lint_parser = subparsers.add_parser(
+        "lint",
+        help="Validate a manifest and dataset bindings",
+    )
+    lint_parser.add_argument(
+        "--manifest",
+        default="report.yaml",
+        help="Path to report manifest (default: report.yaml)",
+    )
+    lint_parser.set_defaults(func=_command_lint)
+
+    scaffold_parser = subparsers.add_parser(
+        "scaffold",
+        help="Create a skeleton manifest from recent history entries",
+    )
+    scaffold_parser.add_argument(
+        "--manifest",
+        default="report.yaml",
+        help="Path where the scaffolded manifest should be written",
+    )
+    scaffold_parser.add_argument(
+        "--limit",
+        type=int,
+        default=3,
+        help="Number of recent history entries to scaffold into datasets",
+    )
+    scaffold_parser.set_defaults(func=_command_scaffold)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    func = getattr(args, "func", None)
+    if func is None:
+        parser.print_help()
+        return 1
+    return int(func(args))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/src/igloo_mcp/reporting/__init__.py
+++ b/src/igloo_mcp/reporting/__init__.py
@@ -1,0 +1,33 @@
+"""Reporting utilities for manifest-driven analytics narratives.
+
+This package provides:
+- Pydantic models for report manifests
+- Helpers for indexing query history and cache artifacts
+- A small builder API for rendering manifests into deterministic outputs
+"""
+
+from __future__ import annotations
+
+from .builder import LintIssue, build_report, lint_report
+from .manifest import (
+    DatasetRef,
+    DatasetSource,
+    ReportManifest,
+    ReportOutput,
+    TemplatesConfig,
+    load_manifest,
+    manifest_json_schema,
+)
+
+__all__ = [
+    "DatasetRef",
+    "DatasetSource",
+    "ReportManifest",
+    "ReportOutput",
+    "TemplatesConfig",
+    "LintIssue",
+    "build_report",
+    "lint_report",
+    "load_manifest",
+    "manifest_json_schema",
+]

--- a/src/igloo_mcp/reporting/builder.py
+++ b/src/igloo_mcp/reporting/builder.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..path_utils import resolve_history_path
+from .history_index import DatasetResolutionError, HistoryIndex, ResolvedDataset
+from .manifest import ReportManifest, ReportOutput, load_manifest
+
+
+@dataclass
+class LintIssue:
+    code: str
+    message: str
+    dataset_name: Optional[str] = None
+    detail: Optional[str] = None
+
+
+def _select_output(manifest: ReportManifest, name: Optional[str]) -> ReportOutput:
+    if name is None:
+        if not manifest.outputs:
+            raise ValueError("Report manifest defines no outputs")
+        return manifest.outputs[0]
+    for output in manifest.outputs:
+        if output.name == name:
+            return output
+    raise ValueError(f"Unknown output name {name!r} in report manifest")
+
+
+def _compute_manifest_hash(path: Path) -> str:
+    data = path.read_bytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def _build_provenance(
+    *,
+    manifest_path: Path,
+    manifest: ReportManifest,
+    datasets: Dict[str, ResolvedDataset],
+) -> Dict[str, Any]:
+    manifest_hash = _compute_manifest_hash(manifest_path)
+    dataset_meta: Dict[str, Any] = {}
+    for name, resolved in datasets.items():
+        dataset_meta[name] = dict(resolved.provenance)
+    return {
+        "manifest_path": str(manifest_path),
+        "manifest_sha256": manifest_hash,
+        "report_id": manifest.id,
+        "datasets": dataset_meta,
+    }
+
+
+def _render_json_payload(
+    *, manifest: ReportManifest, datasets: Dict[str, ResolvedDataset]
+) -> str:
+    serialised_datasets: Dict[str, Any] = {}
+    for name, resolved in datasets.items():
+        serialised_datasets[name] = {
+            "rows": resolved.rows,
+            "columns": resolved.columns,
+            "key_metrics": resolved.key_metrics,
+            "insights": resolved.insights,
+            "provenance": resolved.provenance,
+        }
+    payload = {
+        "manifest": manifest.model_dump(),
+        "datasets": serialised_datasets,
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
+def _render_markdown_with_jinja(
+    *,
+    template_path: Path,
+    manifest: ReportManifest,
+    datasets: Dict[str, ResolvedDataset],
+) -> str:
+    try:  # Import lazily so jinja2 is an optional runtime dependency
+        import jinja2
+    except Exception as exc:  # pragma: no cover - exercised via integration
+        raise RuntimeError(
+            "Template engine 'jinja' requested but jinja2 is not available. "
+            "Install jinja2 or change templates.engine in the manifest."
+        ) from exc
+
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(template_path.parent)),
+        autoescape=False,
+    )
+    template = env.get_template(template_path.name)
+    context = {
+        "manifest": manifest,
+        "datasets": datasets,
+    }
+    return template.render(context)
+
+
+def build_report(
+    manifest_path: Path | str,
+    *,
+    output_name: Optional[str] = None,
+    refresh: bool = False,  # noqa: ARG001 - reserved for future use
+) -> Dict[str, Any]:
+    """Build a report from a manifest.
+
+    For this initial implementation, *refresh* is accepted but ignored; the
+    builder reads only existing history/cache artifacts and does not re-run
+    queries.
+
+    Returns a dictionary with keys:
+        format: Output format string ("markdown" or "json").
+        body: Rendered text payload.
+        provenance: Provenance metadata for audit (manifest hash, execution IDs).
+    """
+
+    manifest_path = Path(manifest_path).expanduser().resolve()
+    manifest = load_manifest(manifest_path)
+    output = _select_output(manifest, output_name)
+
+    history_path = resolve_history_path()
+    index = HistoryIndex(history_path)
+
+    datasets: Dict[str, ResolvedDataset] = {}
+    for ds in manifest.datasets:
+        try:
+            resolved = index.resolve_dataset(ds)
+        except DatasetResolutionError as exc:
+            raise DatasetResolutionError(
+                f"Failed to resolve dataset {ds.name!r}: {exc}"
+            ) from exc
+        datasets[ds.name] = resolved
+
+    provenance = _build_provenance(
+        manifest_path=manifest_path,
+        manifest=manifest,
+        datasets=datasets,
+    )
+
+    template_path = (manifest_path.parent / manifest.templates.main).resolve()
+    if not template_path.exists() and output.format != "json":
+        raise FileNotFoundError(f"Template file not found: {template_path}")
+
+    if output.format == "json":
+        body = _render_json_payload(manifest=manifest, datasets=datasets)
+        return {"format": "json", "body": body, "provenance": provenance}
+
+    # Default narrative format is Markdown; HTML can be derived by callers if
+    # needed by wrapping the Markdown body.
+    markdown = _render_markdown_with_jinja(
+        template_path=template_path,
+        manifest=manifest,
+        datasets=datasets,
+    )
+    return {"format": "markdown", "body": markdown, "provenance": provenance}
+
+
+def lint_report(manifest_path: Path | str) -> List[LintIssue]:
+    """Validate a manifest and its dataset bindings.
+
+    Lint checks performed:
+        - Manifest structure is valid.
+        - Each dataset can be resolved against current history/cache artifacts.
+
+    More advanced drift checks (schema mismatches, value drift) can be layered on
+    top of this in future iterations.
+    """
+
+    manifest_path = Path(manifest_path).expanduser().resolve()
+    issues: List[LintIssue] = []
+
+    try:
+        manifest = load_manifest(manifest_path)
+    except Exception as exc:
+        issues.append(
+            LintIssue(
+                code="manifest_invalid",
+                message=f"Invalid report manifest: {exc}",
+                detail=str(exc),
+            )
+        )
+        return issues
+
+    history_path = resolve_history_path()
+    index = HistoryIndex(history_path)
+
+    for ds in manifest.datasets:
+        try:
+            index.resolve_dataset(ds)
+        except DatasetResolutionError as exc:
+            issues.append(
+                LintIssue(
+                    code="dataset_resolution_error",
+                    message=f"Failed to resolve dataset {ds.name!r}",
+                    dataset_name=ds.name,
+                    detail=str(exc),
+                )
+            )
+
+    return issues
+
+
+__all__ = ["LintIssue", "build_report", "lint_report"]

--- a/src/igloo_mcp/reporting/history_index.py
+++ b/src/igloo_mcp/reporting/history_index.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from ..path_utils import find_repo_root
+from .manifest import DatasetRef, DatasetSource
+
+
+def _load_jsonl(path: Path) -> Iterable[Dict[str, Any]]:
+    """Yield JSON objects from a JSONL file.
+
+    This mirrors the lightweight implementation used in scripts/export_report_bundle.py
+    but lives in the library for reuse by reporting utilities.
+    """
+
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                yield payload
+
+
+@dataclass
+class ResolvedDataset:
+    """Concrete dataset resolved from history/cache artifacts."""
+
+    name: str
+    rows: List[Dict[str, Any]]
+    columns: List[str]
+    key_metrics: Optional[Dict[str, Any]]
+    insights: List[Any]
+    provenance: Dict[str, Any]
+
+
+class DatasetResolutionError(RuntimeError):
+    """Raised when a manifest dataset cannot be bound to artifacts."""
+
+
+class HistoryIndex:
+    """Index over query history used for report dataset resolution.
+
+    The index is intentionally simple: it keeps the raw history records plus
+    lookups by execution_id and sql_sha256. Cache manifests are resolved lazily
+    when datasets are bound.
+    """
+
+    def __init__(self, history_path: Path) -> None:
+        self.history_path = history_path
+        self._records: List[Dict[str, Any]] = list(_load_jsonl(history_path))
+        self._by_execution_id: Dict[str, Dict[str, Any]] = {}
+        self._by_sql_sha: Dict[str, Dict[str, Any]] = {}
+        for record in self._records:
+            exec_id = record.get("execution_id")
+            if isinstance(exec_id, str) and exec_id not in self._by_execution_id:
+                self._by_execution_id[exec_id] = record
+            sha = record.get("sql_sha256")
+            if isinstance(sha, str) and sha not in self._by_sql_sha:
+                self._by_sql_sha[sha] = record
+
+    @property
+    def records(self) -> List[Dict[str, Any]]:
+        return list(self._records)
+
+    def _resolve_history_record(
+        self, source: DatasetSource
+    ) -> Optional[Dict[str, Any]]:
+        if source.execution_id and source.execution_id in self._by_execution_id:
+            return self._by_execution_id[source.execution_id]
+        if source.sql_sha256 and source.sql_sha256 in self._by_sql_sha:
+            return self._by_sql_sha[source.sql_sha256]
+        return None
+
+    @staticmethod
+    def _resolve_manifest_path(cache_manifest: str, repo_root: Optional[Path]) -> Path:
+        candidate = Path(cache_manifest).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        base = repo_root or find_repo_root()
+        return (base / candidate).resolve()
+
+    @staticmethod
+    def _load_cache_manifest(
+        manifest_path: Path,
+    ) -> Tuple[Dict[str, Any], Path, Optional[Path]]:
+        if not manifest_path.exists():
+            raise DatasetResolutionError(f"Cache manifest not found: {manifest_path}")
+        raw = manifest_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise DatasetResolutionError(
+                f"Expected mapping in cache manifest {manifest_path}, got {type(data)!r}"
+            )
+        result_json = data.get("result_json")
+        if not result_json:
+            raise DatasetResolutionError(
+                f"Cache manifest missing result_json field: {manifest_path}"
+            )
+        rows_path = manifest_path.parent / result_json
+        if not rows_path.exists():
+            raise DatasetResolutionError(
+                f"Cache rows file declared in manifest not found: {rows_path}"
+            )
+        result_csv_rel = data.get("result_csv")
+        result_csv_path: Optional[Path] = None
+        if isinstance(result_csv_rel, str) and result_csv_rel:
+            candidate = manifest_path.parent / result_csv_rel
+            if candidate.exists():
+                result_csv_path = candidate
+        return data, rows_path, result_csv_path
+
+    @staticmethod
+    def _load_rows(rows_path: Path) -> List[Dict[str, Any]]:
+        rows: List[Dict[str, Any]] = []
+        for entry in _load_jsonl(rows_path):
+            rows.append(entry)
+        return rows
+
+    def resolve_dataset(
+        self, dataset: DatasetRef, *, repo_root: Optional[Path] = None
+    ) -> ResolvedDataset:
+        """Resolve a single dataset reference into concrete rows + metadata.
+
+        Resolution precedence:
+        1. DatasetSource.cache_manifest if provided.
+        2. History record's artifacts.cache_manifest.
+        3. History record's cache_manifest field.
+        """
+
+        source = dataset.source
+        repo_root = repo_root or find_repo_root()
+
+        manifest_path: Optional[Path] = None
+        history_record: Optional[Dict[str, Any]] = None
+
+        if source.cache_manifest:
+            manifest_path = self._resolve_manifest_path(
+                source.cache_manifest, repo_root
+            )
+        else:
+            history_record = self._resolve_history_record(source)
+            if history_record is None:
+                raise DatasetResolutionError(
+                    f"No history entry found for dataset {dataset.name!r}"
+                )
+            artifacts = history_record.get("artifacts") or {}
+            cache_manifest = artifacts.get("cache_manifest") or history_record.get(
+                "cache_manifest"
+            )
+            if not cache_manifest:
+                raise DatasetResolutionError(
+                    f"History entry for dataset {dataset.name!r} lacks cache_manifest"
+                )
+            manifest_path = self._resolve_manifest_path(str(cache_manifest), repo_root)
+
+        assert manifest_path is not None
+        manifest_data, rows_path, _ = self._load_cache_manifest(manifest_path)
+        rows = self._load_rows(rows_path)
+
+        columns: List[str] = []
+        raw_columns = manifest_data.get("columns")
+        if isinstance(raw_columns, list):
+            columns = [str(col) for col in raw_columns]
+
+        key_metrics = manifest_data.get("key_metrics")
+        if key_metrics is not None and not isinstance(key_metrics, dict):
+            key_metrics = None
+        insights_raw = manifest_data.get("insights") or []
+        insights: List[Any] = (
+            list(insights_raw) if isinstance(insights_raw, list) else []
+        )
+
+        provenance: Dict[str, Any] = {
+            "dataset": dataset.name,
+            "cache_manifest_path": str(manifest_path),
+            "rows_path": str(rows_path),
+            "created_at": manifest_data.get("created_at"),
+            "rowcount": manifest_data.get("rowcount"),
+            "duration_ms": manifest_data.get("duration_ms"),
+            "statement_sha256": manifest_data.get("statement_sha256"),
+        }
+
+        if history_record is None:
+            history_record = self._resolve_history_record(source)
+        if history_record is not None:
+            provenance.setdefault("execution_id", history_record.get("execution_id"))
+            provenance.setdefault("sql_sha256", history_record.get("sql_sha256"))
+            provenance.setdefault("status", history_record.get("status"))
+            if "ts" in history_record:
+                provenance.setdefault("ts", history_record.get("ts"))
+
+        return ResolvedDataset(
+            name=dataset.name,
+            rows=rows,
+            columns=columns,
+            key_metrics=key_metrics,
+            insights=insights,
+            provenance=provenance,
+        )
+
+
+__all__ = ["HistoryIndex", "ResolvedDataset", "DatasetResolutionError"]

--- a/src/igloo_mcp/reporting/manifest.py
+++ b/src/igloo_mcp/reporting/manifest.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional
+
+import yaml  # type: ignore[import-untyped]
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+
+class TemplatesConfig(BaseModel):
+    """Template configuration for a report manifest.
+
+    Attributes:
+        main: Path to the primary narrative template, relative to the manifest file.
+        engine: Template engine identifier (e.g. "jinja").
+        search_paths: Optional additional search paths for templates, relative to
+            the manifest directory.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    main: str = Field(..., description="Primary narrative template path")
+    engine: str = Field("jinja", description="Template engine name")
+    search_paths: List[str] = Field(
+        default_factory=list,
+        description="Additional template search paths, relative to manifest dir",
+    )
+
+
+class DatasetSource(BaseModel):
+    """Source binding for a dataset within a report.
+
+    At least one of execution_id, sql_sha256, or cache_manifest must be
+    provided so the resolver can bind this dataset to concrete history/cache
+    artifacts.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    execution_id: Optional[str] = Field(
+        default=None,
+        description="Execution ID from audit_info.execution_id or history JSONL",
+    )
+    sql_sha256: Optional[str] = Field(
+        default=None,
+        description="SHA-256 hash of the SQL text (statement_sha256)",
+    )
+    cache_manifest: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to a cache manifest.json (absolute or repo-relative). When "
+            "provided, this takes precedence over history lookups."
+        ),
+    )
+    cache_only: bool = Field(
+        default=False,
+        description="If true, do not attempt to re-run queries (reserved).",
+    )
+
+    # Future hints for profile/context overrides (stored but unused for now).
+    profile: Optional[str] = Field(default=None)
+    warehouse: Optional[str] = Field(default=None)
+    database: Optional[str] = Field(default=None)
+    db_schema: Optional[str] = Field(default=None, alias="schema")
+    role: Optional[str] = Field(default=None)
+
+    @model_validator(mode="after")
+    def _ensure_identifier(self) -> "DatasetSource":  # pragma: no cover - simple guard
+        if not (self.execution_id or self.sql_sha256 or self.cache_manifest):
+            raise ValueError(
+                "DatasetSource requires at least one of execution_id, "
+                "sql_sha256, or cache_manifest"
+            )
+        return self
+
+
+class DatasetRef(BaseModel):
+    """Logical dataset used by a report.
+
+    The name is used as the key inside the template context under
+    ``datasets[name]``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Template-visible dataset identifier")
+    description: Optional[str] = Field(
+        default=None, description="Optional human-readable description"
+    )
+    source: DatasetSource = Field(..., description="Backing query/cache binding")
+    tags: List[str] = Field(default_factory=list)
+
+
+class ReportOutput(BaseModel):
+    """Single named output for a report build.
+
+    For example, a Markdown narrative, an HTML export, or a JSON payload used by
+    downstream systems.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Logical name for this output")
+    format: Literal["markdown", "html", "json"] = Field(
+        ...,
+        description="Output format identifier",
+    )
+    path: str = Field(
+        ...,
+        description="Destination path for the rendered output",
+    )
+    from_output: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional upstream output to derive from (e.g. HTML from Markdown)."
+        ),
+    )
+
+
+class ReportManifest(BaseModel):
+    """Top-level manifest describing a narrative analytics report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., description="Stable identifier for this report")
+    title: Optional[str] = Field(default=None)
+    version: Optional[str] = Field(default=None)
+    author: Optional[str] = Field(default=None)
+    created_at: Optional[str] = Field(default=None)
+    updated_at: Optional[str] = Field(default=None)
+
+    templates: TemplatesConfig
+    datasets: List[DatasetRef] = Field(default_factory=list)
+    outputs: List[ReportOutput] = Field(default_factory=list)
+
+
+def _load_yaml_file(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Manifest file not found: {path}")
+    raw = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(raw) or {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Expected mapping at root of manifest {path}, got {type(data)!r}"
+        )
+    return data
+
+
+def load_manifest(path: Path | str) -> ReportManifest:
+    """Load and validate a report manifest from YAML.
+
+    The *path* may be absolute or relative. Relative paths are resolved
+    relative to the current working directory. Callers that need repo-root
+    resolution should construct an absolute path beforehand.
+    """
+
+    manifest_path = Path(path).expanduser().resolve()
+    data = _load_yaml_file(manifest_path)
+    try:
+        return ReportManifest(**data)
+    except ValidationError as exc:
+        # Re-raise as ValueError for a simpler public surface while keeping
+        # the original error for debugging when needed.
+        raise ValueError(f"Invalid report manifest at {manifest_path}: {exc}") from exc
+
+
+def manifest_json_schema() -> Dict[str, Any]:
+    """Return the JSON schema for :class:`ReportManifest`."""
+
+    return ReportManifest.model_json_schema()
+
+
+__all__ = [
+    "TemplatesConfig",
+    "DatasetSource",
+    "DatasetRef",
+    "ReportOutput",
+    "ReportManifest",
+    "load_manifest",
+    "manifest_json_schema",
+]

--- a/tests/test_report_cli_entrypoint.py
+++ b/tests/test_report_cli_entrypoint.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import argparse
+
+from igloo_mcp import report_cli
+
+
+def test_build_arg_parser_has_subcommands() -> None:
+    parser = report_cli.build_arg_parser()
+    assert isinstance(parser, argparse.ArgumentParser)
+    # Ensure the expected subcommands are registered
+    subcommands = set()
+    for action in parser._actions:  # type: ignore[attr-defined]
+        if isinstance(action, argparse._SubParsersAction):  # type: ignore[attr-defined]
+            subcommands.update(action.choices.keys())
+    assert {"build", "lint", "scaffold"}.issubset(subcommands)

--- a/tests/test_report_mcp_tools.py
+++ b/tests/test_report_mcp_tools.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from igloo_mcp import mcp_server
+
+
+class CapturingServer:
+    """Minimal FastMCP-like server that records registered tools."""
+
+    def __init__(self) -> None:
+        self.tools: Dict[str, Any] = {}
+
+    def tool(self, *, name: str, description: str):  # noqa: D401, ARG002
+        def decorator(func):
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+    def resource(self, uri: str, **_: Any):  # noqa: D401, ARG002
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+class StubService:
+    """SnowflakeService stub sufficient for register_igloo_mcp()."""
+
+    def get_query_tag_param(self) -> None:
+        return None
+
+    def get_connection(self, **_: Any):  # type: ignore[override]
+        class _ConnCtx:
+            def __enter__(self):
+                return None, None
+
+            def __exit__(self, exc_type, exc, tb):  # noqa: D401, ARG002
+                return False
+
+        return _ConnCtx()
+
+
+@pytest.mark.asyncio
+async def test_report_build_tool_json_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Prepare a minimal cache manifest + rows payload
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    rows_path = cache_dir / "rows.jsonl"
+    rows = [{"id": 1, "value": "a"}, {"id": 2, "value": "b"}]
+    with rows_path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row))
+            fh.write("\n")
+
+    manifest_json_path = cache_dir / "manifest.json"
+    manifest_json_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "cache_key": "demo-key",
+                "created_at": "2025-01-01T00:00:00Z",
+                "profile": "test-profile",
+                "context": {},
+                "rowcount": len(rows),
+                "duration_ms": 10,
+                "statement_sha256": "deadbeef",
+                "result_json": rows_path.name,
+                "result_csv": None,
+                "columns": ["id", "value"],
+                "truncated": False,
+                "key_metrics": {"total_rows": len(rows)},
+                "insights": ["example insight"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # History file is required by HistoryIndex but can be empty
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        "igloo_mcp.reporting.builder.resolve_history_path",
+        lambda: history_path,
+        raising=True,
+    )
+
+    # Manifest referencing the cache manifest directly
+    report_manifest_path = tmp_path / "report.yaml"
+    report_manifest_path.write_text(
+        f"""
+id: "demo-report"
+templates:
+  main: "templates/report.md"
+datasets:
+  - name: "cached_dataset"
+    source:
+      cache_manifest: "{manifest_json_path}"
+outputs:
+  - name: "default"
+    format: "json"
+    path: "reports/demo.json"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    server = CapturingServer()
+    service = StubService()
+    # Registration will attach all tools, including the reporting helpers
+    mcp_server.register_igloo_mcp(server, service)
+
+    tool = server.tools["report_build"]
+    result = await tool(str(report_manifest_path), "default", "json", False, None)
+
+    assert result["format"] == "json"
+    assert result["manifest_path"] == str(report_manifest_path.resolve())
+
+    body = result["body"]
+    payload = json.loads(body)
+    assert "datasets" in payload
+    assert "cached_dataset" in payload["datasets"]
+    ds = payload["datasets"]["cached_dataset"]
+    assert ds["columns"] == ["id", "value"]
+    assert ds["key_metrics"]["total_rows"] == len(rows)
+    assert len(ds["rows"]) == len(rows)
+
+
+@pytest.mark.asyncio
+async def test_report_lint_tool_flags_missing_cache(tmp_path: Path) -> None:
+    # History file can be empty; dataset references a missing cache manifest
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text("", encoding="utf-8")
+
+    # Small manifest with an unresolvable dataset
+    report_manifest_path = tmp_path / "report.yaml"
+    report_manifest_path.write_text(
+        """
+id: "lint-demo"
+templates:
+  main: "templates/report.md"
+datasets:
+  - name: "missing"
+    source:
+      cache_manifest: "nonexistent/manifest.json"
+outputs:
+  - name: "default"
+    format: "json"
+    path: "reports/demo.json"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    server = CapturingServer()
+    service = StubService()
+    mcp_server.register_igloo_mcp(server, service)
+
+    tool = server.tools["report_lint"]
+    result = await tool(str(report_manifest_path))
+
+    assert result["manifest_path"] == str(report_manifest_path.resolve())
+    assert result["ok"] is False
+    assert result["issues"]

--- a/tests/test_reporting_builder.py
+++ b/tests/test_reporting_builder.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from igloo_mcp.reporting.builder import build_report, lint_report
+
+
+def test_lint_report_flags_missing_cache_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Point history to an empty JSONL file to keep the index trivial.
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "igloo_mcp.reporting.builder.resolve_history_path",
+        lambda: history_path,
+        raising=True,
+    )
+
+    manifest_path = tmp_path / "report.yaml"
+    manifest_path.write_text(
+        """
+id: "demo-report"
+templates:
+  main: "templates/report.md"
+datasets:
+  - name: "unbound"
+    source:
+      cache_manifest: "nonexistent/manifest.json"
+outputs:
+  - name: "default"
+    format: "json"
+    path: "reports/demo.json"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    issues = lint_report(manifest_path)
+    assert issues, "Expected lint issues for unresolved dataset"
+    assert any(
+        issue.code == "dataset_resolution_error" and issue.dataset_name == "unbound"
+        for issue in issues
+    )
+
+
+def test_build_report_json_with_cache_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Create a minimal cache manifest + rows payload
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    rows_path = cache_dir / "rows.jsonl"
+    rows = [{"id": 1, "value": "a"}, {"id": 2, "value": "b"}]
+    with rows_path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row))
+            fh.write("\n")
+
+    manifest_json_path = cache_dir / "manifest.json"
+    manifest_json_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "cache_key": "demo-key",
+                "created_at": "2025-01-01T00:00:00Z",
+                "profile": "test-profile",
+                "context": {},
+                "rowcount": len(rows),
+                "duration_ms": 10,
+                "statement_sha256": "deadbeef",
+                "result_json": rows_path.name,
+                "result_csv": None,
+                "columns": ["id", "value"],
+                "truncated": False,
+                "key_metrics": {"total_rows": len(rows)},
+                "insights": ["example insight"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        "igloo_mcp.reporting.builder.resolve_history_path",
+        lambda: history_path,
+        raising=True,
+    )
+
+    report_manifest_path = tmp_path / "report.yaml"
+    report_manifest_path.write_text(
+        f"""
+id: "demo-report"
+templates:
+  main: "templates/report.md"
+datasets:
+  - name: "cached_dataset"
+    source:
+      cache_manifest: "{manifest_json_path}"
+outputs:
+  - name: "default"
+    format: "json"
+    path: "reports/demo.json"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = build_report(report_manifest_path, output_name="default")
+    assert result["format"] == "json"
+    body = result["body"]
+    payload = json.loads(body)
+    assert "datasets" in payload
+    assert "cached_dataset" in payload["datasets"]
+    ds = payload["datasets"]["cached_dataset"]
+    assert ds["columns"] == ["id", "value"]
+    assert ds["key_metrics"]["total_rows"] == len(rows)
+    assert len(ds["rows"]) == len(rows)

--- a/tests/test_reporting_manifest.py
+++ b/tests/test_reporting_manifest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from igloo_mcp.reporting.manifest import (
+    DatasetRef,
+    DatasetSource,
+    ReportManifest,
+    TemplatesConfig,
+    load_manifest,
+    manifest_json_schema,
+)
+
+
+def test_load_manifest_minimal(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "report.yaml"
+    manifest_path.write_text(
+        """
+id: "demo-report"
+title: "Demo Report"
+templates:
+  main: "templates/report.md"
+datasets:
+  - name: "sales"
+    source:
+      execution_id: "exec-123"
+outputs:
+  - name: "default"
+    format: "markdown"
+    path: "reports/demo.md"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    manifest = load_manifest(manifest_path)
+
+    assert isinstance(manifest, ReportManifest)
+    assert manifest.id == "demo-report"
+    assert manifest.templates.main == "templates/report.md"
+    assert len(manifest.datasets) == 1
+    assert manifest.datasets[0].name == "sales"
+    assert manifest.datasets[0].source.execution_id == "exec-123"
+    assert len(manifest.outputs) == 1
+    assert manifest.outputs[0].format == "markdown"
+
+
+def test_manifest_json_schema_contains_key_fields() -> None:
+    schema = manifest_json_schema()
+    assert isinstance(schema, dict)
+    properties = schema.get("properties") or {}
+    assert "id" in properties
+    assert "templates" in properties
+    assert "datasets" in properties
+    assert "outputs" in properties
+
+
+def test_dataset_source_requires_identifier() -> None:
+    # At least one identifier must be present
+    try:
+        DatasetSource()  # type: ignore[call-arg]
+    except Exception:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("DatasetSource should require an identifier")
+
+    src = DatasetSource(execution_id="abc")
+    ref = DatasetRef(name="demo", source=src)
+    manifest = ReportManifest(
+        id="demo", templates=TemplatesConfig(main="tmpl.md"), datasets=[ref], outputs=[]
+    )
+    assert manifest.datasets[0].source.execution_id == "abc"


### PR DESCRIPTION
## Context
- Bundle PR #31 (reporting/manifest builder) with PR #32 (query tooling + REST driver + reporting refinements).
- Add a default report template so scaffolded manifests render out of the box and stay modular for future swaps.

## Plan
1) Merge PR #32 on top of this branch and resolve conflicts (mcp_server.py, tests/test_report_mcp_tools.py).
2) Add a default Markdown template (e.g., templates/report.md) and point scaffolded manifests at it; keep manifest override for template updates.
3) Keep backward-compatible report_lint tool (shim over report_build validate_only) to avoid breaking clients.
4) Harden REST driver initialization: warn/fail when REST env is incomplete instead of silently falling back to CLI.

## Validation (to run on this branch)
- pytest tests/test_report_*
- pytest tests/test_execute_query.py tests/test_cache_golden_fixtures.py
- pytest tests/test_query_optimizer.py tests/test_query_service_rest.py tests/test_sql_objects.py

## Landing
- After conflicts are resolved and tests pass, squash/merge to main with changelog notes covering: reporting tools additions, default template, report_lint compatibility, and REST driver expectations.
