### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-03-15
+
+### Provider Auth and Release Hardening
+
+### ✨ Added
+
+- Added keypair-auth Snowflake provider support with persistent connector sessions, provider-specific retry policy defaults, and circuit-breaker diagnostics.
+- Added FastMCP compatibility shims plus expanded execute-query coverage for timeout handling, retry behavior, query-service fallbacks, and parallel timeout execution.
+- Added deterministic cache artifact baselines so golden-fixture validation runs as a real assertion in CI.
+
+### 🐛 Bug Fixes
+
+- Restored `execute_query` constructor compatibility for existing callers and preserved validated statement types so safe read-only retries still execute after upfront validation.
+- Fixed `execute_query` full-result truncation, file-export handling, and health/remediation payload regressions introduced by the broader refactor.
+- Fixed `search_report` and `evolve_report` published schemas to match their live parameters, including field selection and response verbosity controls.
+
+### 🧪 Testing
+
+- Removed avoidable non-Snowflake skips by activating schema-validation, SQL-validation, insight-removal, post-query-insight snapshot, and cache golden-fixture tests.
+- Full non-Snowflake validation now passes with `1264 passed, 1 xfailed, 1 xpassed`, plus lint, import-lint, `mypy`, and critical coverage checks.
+
 ## [0.4.3] - 2026-02-06
 
 ### ✨ Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "igloo_mcp"
-version = "0.4.3"
+version = "0.5.0"
 description = "Igloo MCP - Snowflake MCP Server for agentic native workflows"
 readme = "README.md"
 authors = [

--- a/src/igloo_mcp/__init__.py
+++ b/src/igloo_mcp/__init__.py
@@ -5,7 +5,7 @@ from .config import Config, get_config, set_config
 from .parallel import ParallelQueryConfig, ParallelQueryExecutor, query_multiple_objects
 from .snow_cli import SnowCLI
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 __all__ = [
     "Config",
     "ParallelQueryConfig",


### PR DESCRIPTION
## Summary
- bump package version to 0.5.0
- add 0.5.0 changelog entry for provider auth, execute_query hardening, and skip-cleanup work
- release from the now-merged #161 and #163 baseline

## Validation
- uv run ruff check . --output-format=github
- uv run ruff format --check .
- uv run lint-imports
- uv run mypy src/ --ignore-missing-imports
- uv run pytest --cov=src/igloo_mcp --cov-report=xml --cov-report=term-missing --cov-fail-under=70 -q -ra
- uv run python scripts/check_critical_coverage.py --coverage-file coverage.xml --min-coverage 55 --critical-modules "mcp/tools" "service_layer" "sql_validation.py"