### PR TITLE
fix(ci): support manual PyPI release dispatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -96,16 +97,33 @@ jobs:
             --notes "${{ steps.release_notes.notes }}" \
             --verify-tag
 
+      - name: Trigger PyPI publish workflow
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yml \
+            --ref main \
+            -f tag="${{ steps.version.outputs.tag }}"
+
       - name: Comment on PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          COMMENT="🎉 **Release ${{ steps.version.outputs.tag }} Created!**
+          if [ "${{ steps.check_tag.outputs.exists }}" = "false" ]; then
+            COMMENT="🎉 **Release ${{ steps.version.outputs.tag }} Created!**
 
           - ✅ Tag created and pushed
           - ✅ GitHub release published
-          - ✅ PyPI publish triggered (see [release workflow](https://github.com/${{ github.repository }}/actions/workflows/release.yml))
+          - ✅ PyPI publish requested (see [release workflow](https://github.com/${{ github.repository }}/actions/workflows/release.yml))
           "
+          else
+            COMMENT="ℹ️ **Release ${{ steps.version.outputs.tag }} already existed**
+
+          - ℹ️ Tag already existed, so no new GitHub release was created
+          - ℹ️ No new PyPI publish was requested automatically
+          "
+          fi
 
           if [ -n "${{ steps.extract_issues.outputs.issues }}" ]; then
             COMMENT="$COMMENT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to publish (for example, v0.5.0)
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -15,7 +21,25 @@ jobs:
       contents: read
 
     steps:
+      - name: Resolve release target
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TARGET_TAG="${{ inputs.tag }}"
+          else
+            TARGET_TAG="${{ github.ref_name }}"
+          fi
+
+          if [ -z "$TARGET_TAG" ] || ! echo "$TARGET_TAG" | grep -Eq '^v[0-9]'; then
+            echo "Expected a version tag like v0.5.0, got: ${TARGET_TAG:-<empty>}" >&2
+            exit 1
+          fi
+
+          echo "tag=$TARGET_TAG" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.tag }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary
- add workflow_dispatch support to the PyPI release workflow so an existing tag can be published explicitly
- have auto-release dispatch the PyPI workflow instead of relying on a tag push from Actions
- correct the auto-release PR comment so it reflects whether a release was actually created

## Testing
- inspected workflow diff locally
- will validate by dispatching the v0.5.0 publish run after merge