### PR TITLE
feat: add Living Reports storage checks to health_check

### DIFF
--- a/docs/api/tools/health_check.md
+++ b/docs/api/tools/health_check.md
@@ -11,14 +11,15 @@ Get comprehensive health status for the MCP server and Snowflake connection.
 | `include_cortex` | boolean | ❌ No | true | Check Cortex AI availability |
 | `include_profile` | boolean | ❌ No | true | Validate profile configuration |
 | `include_catalog` | boolean | ❌ No | false | Check catalog resource status |
+| `include_reports_health` | boolean | ❌ No | false | Check Living Reports storage integrity, audits, and disk pressure |
 | `request_id` | string | ❌ No | auto-generated | Request correlation ID for distributed tracing (UUID4). Auto-generated if not provided. |
 
 ## Discovery Metadata
 
 - **Category:** `diagnostics`
-- **Tags:** `health`, `profile`, `cortex`, `catalog`, `diagnostics`
+- **Tags:** `health`, `profile`, `cortex`, `catalog`, `reports`, `diagnostics`
 - **Usage Examples:**
-  1. `include_cortex=true`, `include_catalog=true` to perform the full suite of checks.
+  1. `include_cortex=true`, `include_catalog=true`, `include_reports_health=true` to perform the full suite of checks.
   2. `include_cortex=false`, `include_catalog=false` for a fast profile-only validation.
 
 ## Returns
@@ -102,6 +103,43 @@ When `response_mode="full"`, the response includes a `diagnostics.storage_paths`
 ```
 
 When available, full diagnostics also include `diagnostics.query_circuit_breaker` mirroring the current `execute_query` circuit breaker status.
+
+### Living Reports Diagnostics
+
+When `include_reports_health=true`, the `checks.reports` object includes a read-only audit of the Living Reports filesystem:
+
+- `status`: `healthy`, `warning`, or `unhealthy`
+- `total_reports` and `index_entries`
+- `corrupted_index_lines`, `orphaned_index_entries`, and `missing_index_entries`
+- `total_audit_events`, `corrupted_audit_logs`, and `missing_audit_logs`
+- `total_size_bytes` / `total_size_mb` and average per-report size
+- `disk_usage.used_percent` with warnings when the underlying volume approaches capacity
+- `orphaned_assets` for files under `report_files/` that are not referenced by any report outline
+- `old_backups` for backup files older than the retention window (`backup_retention_days`, currently 30)
+
+Example:
+
+```json
+{
+  "checks": {
+    "reports": {
+      "status": "warning",
+      "total_reports": 42,
+      "index_entries": 42,
+      "orphaned_index_entries": [],
+      "missing_index_entries": [],
+      "total_audit_events": 389,
+      "total_size_mb": 156.3,
+      "disk_usage": {
+        "used_percent": 82.4
+      },
+      "orphaned_assets": [],
+      "old_backups": [],
+      "warnings": []
+    }
+  }
+}
+```
 
 **Storage Scope Modes:**
 - `global`: All data stored in `~/.igloo_mcp/` (default, persistent across projects)

--- a/src/igloo_mcp/mcp/tools/health.py
+++ b/src/igloo_mcp/mcp/tools/health.py
@@ -286,7 +286,7 @@ class HealthCheckTool(MCPTool):
             breaker_state = results.get("query_circuit_breaker", {}).get("state")
             if breaker_state == "open":
                 retry_after = results.get("query_circuit_breaker", {}).get("time_until_retry_seconds")
-                if isinstance(retry_after, (int, float)):
+                if isinstance(retry_after, int | float):
                     remediation["query_circuit_breaker"] = (
                         f"execute_query circuit breaker is open. Retry in ~{round(float(retry_after), 2)}s "
                         "or resolve Snowflake connectivity issues."

--- a/src/igloo_mcp/mcp/tools/health.py
+++ b/src/igloo_mcp/mcp/tools/health.py
@@ -5,8 +5,11 @@ Part of v1.9.0 Phase 1 - consolidates health_check, check_profile_config, and ge
 
 from __future__ import annotations
 
+import json
+import shutil
 import time
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import anyio
@@ -36,6 +39,9 @@ class HealthCheckTool(MCPTool):
     - check_profile_config (profile validation)
     - get_resource_status (catalog availability)
     """
+
+    REPORT_BACKUP_RETENTION_DAYS = 30
+    REPORTS_DISK_WARNING_THRESHOLD_PERCENT = 90.0
 
     def __init__(
         self,
@@ -68,7 +74,7 @@ class HealthCheckTool(MCPTool):
 
     @property
     def description(self) -> str:
-        return "Check server, connection, and catalog health. Use response_mode='minimal' for quick status."
+        return "Check server, connection, catalog, and reports health. Use response_mode='minimal' for quick status."
 
     @property
     def category(self) -> str:
@@ -76,7 +82,7 @@ class HealthCheckTool(MCPTool):
 
     @property
     def tags(self) -> list[str]:
-        return ["health", "profile", "cortex", "catalog", "diagnostics"]
+        return ["health", "profile", "cortex", "catalog", "reports", "diagnostics"]
 
     @property
     def usage_examples(self) -> list[dict[str, Any]]:
@@ -86,6 +92,7 @@ class HealthCheckTool(MCPTool):
                 "parameters": {
                     "include_cortex": True,
                     "include_catalog": True,
+                    "include_reports_health": True,
                 },
             },
             {
@@ -105,6 +112,7 @@ class HealthCheckTool(MCPTool):
         include_cortex: bool = True,
         include_profile: bool = True,
         include_catalog: bool = False,
+        include_reports_health: bool = False,
         request_id: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
@@ -119,6 +127,7 @@ class HealthCheckTool(MCPTool):
             include_cortex: Check Cortex AI services availability
             include_profile: Validate profile configuration
             include_catalog: Check catalog availability
+            include_reports_health: Validate Living Reports storage health
             request_id: Optional request ID for tracing
 
         Returns:
@@ -143,6 +152,7 @@ class HealthCheckTool(MCPTool):
                 "include_cortex": include_cortex,
                 "include_profile": include_profile,
                 "include_catalog": include_catalog,
+                "include_reports_health": include_reports_health,
                 "request_id": request_id,
             },
         )
@@ -164,6 +174,10 @@ class HealthCheckTool(MCPTool):
         if include_catalog:
             results["catalog"] = await self._check_catalog_exists()
 
+        # Optional: Check living reports storage
+        if include_reports_health:
+            results["reports"] = await anyio.to_thread.run_sync(self._check_reports_health)
+
         # Include system health metrics if monitor available
         if self.health_monitor:
             results["system"] = self._get_system_health()
@@ -172,8 +186,10 @@ class HealthCheckTool(MCPTool):
             results["query_circuit_breaker"] = self._get_query_circuit_breaker_status()
 
         # Overall status
-        has_critical_failures = not results["connection"].get("connected", False) or (
-            include_profile and results.get("profile", {}).get("status") == "invalid"
+        has_critical_failures = (
+            not results["connection"].get("connected", False)
+            or (include_profile and results.get("profile", {}).get("status") == "invalid")
+            or (include_reports_health and results.get("reports", {}).get("status") in {"unhealthy", "error"})
         )
 
         results["overall_status"] = "unhealthy" if has_critical_failures else "healthy"
@@ -197,6 +213,7 @@ class HealthCheckTool(MCPTool):
         snowflake_health = results.get("connection", {}).get("status", "unknown")
         catalog_health = results.get("catalog", {}).get("status", "unknown")
         profile_health = results.get("profile", {}).get("status", "unknown")
+        reports_health = results.get("reports", {}).get("status", "unknown")
 
         # Build response based on response_mode
         if mode == "minimal":
@@ -207,6 +224,7 @@ class HealthCheckTool(MCPTool):
                     "snowflake": snowflake_health,
                     "catalog": catalog_health,
                     "profile": profile_health,
+                    "reports": reports_health,
                     "query_circuit_breaker": results.get("query_circuit_breaker", {}).get("state", "unavailable"),
                 },
             }
@@ -255,6 +273,14 @@ class HealthCheckTool(MCPTool):
                 remediation["profile"] = (
                     f"Profile '{profile_name}' configuration issues detected. "
                     "Check ~/.snowflake/config.toml or run test_connection"
+                )
+
+            reports_status = results.get("reports", {}).get("status", "unknown")
+            if reports_status in {"warning", "unhealthy", "error"}:
+                remediation["reports"] = (
+                    "Living Reports storage issues detected. Run "
+                    "health_check(include_reports_health=True, response_mode='full') "
+                    "and repair index, audit, or asset inconsistencies."
                 )
 
             breaker_state = results.get("query_circuit_breaker", {}).get("state")
@@ -490,6 +516,201 @@ class HealthCheckTool(MCPTool):
                 "error": str(e),
             }
 
+    def _check_reports_health(self) -> dict[str, Any]:
+        """Inspect Living Reports storage without mutating on-disk state."""
+        from igloo_mcp.living_reports.models import AuditEvent, IndexEntry
+        from igloo_mcp.path_utils import resolve_reports_root
+
+        def _nearest_existing_path(path):
+            current = path
+            while not current.exists() and current != current.parent:
+                current = current.parent
+            return current
+
+        def _collect_report_file_references(value: Any, found: set[str]) -> None:
+            if isinstance(value, dict):
+                for nested in value.values():
+                    _collect_report_file_references(nested, found)
+                return
+            if isinstance(value, list):
+                for nested in value:
+                    _collect_report_file_references(nested, found)
+                return
+            if not isinstance(value, str):
+                return
+
+            normalized = value.replace("\\", "/").strip()
+            if normalized.startswith("report_files/") and "/../" not in normalized and not normalized.endswith("/.."):
+                found.add(normalized)
+
+        def _directory_size_bytes(path) -> int:
+            if not path.exists():
+                return 0
+            total = 0
+            for file_path in path.rglob("*"):
+                if not file_path.is_file():
+                    continue
+                try:
+                    total += file_path.stat().st_size
+                except OSError:
+                    continue
+            return total
+
+        reports_root = resolve_reports_root()
+        by_id_dir = reports_root / "by_id"
+        index_path = reports_root / "index.jsonl"
+        initialized = reports_root.exists() or index_path.exists() or by_id_dir.exists()
+
+        report_dirs = sorted(path for path in by_id_dir.iterdir() if path.is_dir()) if by_id_dir.exists() else []
+        report_ids = {path.name for path in report_dirs}
+
+        parsed_index_entries: dict[str, Any] = {}
+        corrupted_index_lines: list[dict[str, Any]] = []
+        if index_path.exists():
+            try:
+                with index_path.open("r", encoding="utf-8") as handle:
+                    for line_number, raw_line in enumerate(handle, 1):
+                        line = raw_line.strip()
+                        if not line:
+                            continue
+                        try:
+                            entry = IndexEntry(**json.loads(line))
+                            parsed_index_entries[entry.report_id] = entry
+                        except Exception as exc:
+                            corrupted_index_lines.append({"line": line_number, "error": str(exc)})
+            except OSError as exc:
+                corrupted_index_lines.append({"line": 0, "error": str(exc)})
+
+        indexed_report_ids = set(parsed_index_entries)
+        orphaned_index_entries = sorted(indexed_report_ids - report_ids)
+        missing_index_entries = sorted(report_ids - indexed_report_ids)
+
+        total_audit_events = 0
+        corrupted_audit_logs: list[dict[str, Any]] = []
+        missing_audit_logs: list[str] = []
+        orphaned_assets: list[str] = []
+        old_backups: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        now = datetime.now(UTC)
+        backup_cutoff = now - timedelta(days=self.REPORT_BACKUP_RETENTION_DAYS)
+
+        for report_dir in report_dirs:
+            report_id = report_dir.name
+            audit_path = report_dir / "audit.jsonl"
+            outline_path = report_dir / "outline.json"
+
+            if audit_path.exists():
+                try:
+                    with audit_path.open("r", encoding="utf-8") as handle:
+                        for line_number, raw_line in enumerate(handle, 1):
+                            line = raw_line.strip()
+                            if not line:
+                                continue
+                            try:
+                                AuditEvent(**json.loads(line))
+                                total_audit_events += 1
+                            except Exception as exc:
+                                corrupted_audit_logs.append(
+                                    {"report_id": report_id, "line": line_number, "error": str(exc)}
+                                )
+                except OSError as exc:
+                    corrupted_audit_logs.append({"report_id": report_id, "line": 0, "error": str(exc)})
+            else:
+                missing_audit_logs.append(report_id)
+
+            referenced_assets: set[str] = set()
+            outline_data: Any | None = None
+            if outline_path.exists():
+                try:
+                    outline_data = json.loads(outline_path.read_text(encoding="utf-8"))
+                except Exception as exc:
+                    warnings.append(f"Unable to inspect asset references for report {report_id}: {exc}")
+            else:
+                warnings.append(f"Report {report_id} is missing outline.json")
+
+            if outline_data is not None:
+                _collect_report_file_references(outline_data, referenced_assets)
+
+            report_files_dir = report_dir / "report_files"
+            if report_files_dir.exists():
+                for asset_path in sorted(path for path in report_files_dir.rglob("*") if path.is_file()):
+                    relative_asset = asset_path.relative_to(report_dir).as_posix()
+                    if outline_data is not None and relative_asset not in referenced_assets:
+                        orphaned_assets.append(f"{report_id}/{relative_asset}")
+
+            backups_dir = report_dir / "backups"
+            if backups_dir.exists():
+                for backup_path in sorted(path for path in backups_dir.rglob("*.bak") if path.is_file()):
+                    try:
+                        modified_at = datetime.fromtimestamp(backup_path.stat().st_mtime, tz=UTC)
+                    except OSError:
+                        continue
+                    if modified_at < backup_cutoff:
+                        old_backups.append(
+                            {
+                                "path": f"{report_id}/{backup_path.relative_to(report_dir).as_posix()}",
+                                "age_days": int((now - modified_at).total_seconds() // 86400),
+                            }
+                        )
+
+        if missing_audit_logs:
+            warnings.append(f"{len(missing_audit_logs)} report(s) are missing audit.jsonl")
+        if orphaned_assets:
+            warnings.append(f"{len(orphaned_assets)} orphaned report asset(s) detected")
+        if old_backups:
+            warnings.append(
+                f"{len(old_backups)} backup file(s) exceed {self.REPORT_BACKUP_RETENTION_DAYS}-day retention"
+            )
+
+        total_size_bytes = _directory_size_bytes(reports_root)
+        total_reports = len(report_dirs)
+        average_report_size_bytes = int(total_size_bytes / total_reports) if total_reports else 0
+
+        disk_anchor = _nearest_existing_path(reports_root)
+        usage = shutil.disk_usage(disk_anchor)
+        disk_used_bytes = usage.total - usage.free
+        disk_used_percent = round((disk_used_bytes / usage.total) * 100, 2) if usage.total else 0.0
+        if disk_used_percent >= self.REPORTS_DISK_WARNING_THRESHOLD_PERCENT:
+            warnings.append(
+                f"Disk usage for {disk_anchor} is {disk_used_percent}% "
+                f"(threshold {self.REPORTS_DISK_WARNING_THRESHOLD_PERCENT:.0f}%)"
+            )
+
+        status = "healthy"
+        if corrupted_index_lines or orphaned_index_entries or missing_index_entries or corrupted_audit_logs:
+            status = "unhealthy"
+        elif warnings:
+            status = "warning"
+
+        return {
+            "status": status,
+            "initialized": initialized,
+            "reports_root": str(reports_root),
+            "total_reports": total_reports,
+            "index_exists": index_path.exists(),
+            "index_entries": len(parsed_index_entries),
+            "corrupted_index_lines": corrupted_index_lines,
+            "orphaned_index_entries": orphaned_index_entries,
+            "missing_index_entries": missing_index_entries,
+            "total_audit_events": total_audit_events,
+            "corrupted_audit_logs": corrupted_audit_logs,
+            "missing_audit_logs": missing_audit_logs,
+            "total_size_bytes": total_size_bytes,
+            "total_size_mb": round(total_size_bytes / (1024 * 1024), 2),
+            "average_report_size_bytes": average_report_size_bytes,
+            "average_report_size_mb": round(average_report_size_bytes / (1024 * 1024), 2),
+            "disk_usage": {
+                "path": str(disk_anchor),
+                "total_bytes": usage.total,
+                "free_bytes": usage.free,
+                "used_percent": disk_used_percent,
+            },
+            "orphaned_assets": orphaned_assets,
+            "backup_retention_days": self.REPORT_BACKUP_RETENTION_DAYS,
+            "old_backups": old_backups,
+            "warnings": warnings,
+        }
+
     def _get_system_health(self) -> dict[str, Any]:
         """Get system health metrics from monitor."""
         if not self.health_monitor:
@@ -628,6 +849,10 @@ class HealthCheckTool(MCPTool):
                 ),
                 "include_catalog": boolean_schema(
                     "Check catalog health",
+                    default=False,
+                ),
+                "include_reports_health": boolean_schema(
+                    "Check Living Reports storage health",
                     default=False,
                 ),
             },

--- a/src/igloo_mcp/mcp_server.py
+++ b/src/igloo_mcp/mcp_server.py
@@ -835,6 +835,10 @@ def register_igloo_mcp(
         include_cortex: Annotated[bool, Field(description="Check Cortex availability", default=True)] = True,
         include_profile: Annotated[bool, Field(description="Check profile config", default=True)] = True,
         include_catalog: Annotated[bool, Field(description="Check catalog health", default=False)] = False,
+        include_reports_health: Annotated[
+            bool,
+            Field(description="Check Living Reports storage health", default=False),
+        ] = False,
     ) -> dict[str, Any]:
         """Get health status - delegates to HealthCheckTool."""
         return await health_check_inst.execute(
@@ -843,6 +847,7 @@ def register_igloo_mcp(
             include_cortex=include_cortex,
             include_profile=include_profile,
             include_catalog=include_catalog,
+            include_reports_health=include_reports_health,
         )
 
     @server.tool(name="list_profiles", description="List available Snowflake connection profiles")

--- a/tests/test_health_check_tool.py
+++ b/tests/test_health_check_tool.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import json
+import os
 import sys
 import types
+import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from igloo_mcp.config import Config
+from igloo_mcp.living_reports.models import IndexEntry
+from igloo_mcp.living_reports.service import ReportService
 from igloo_mcp.mcp.tools.health import HealthCheckTool
 from igloo_mcp.mcp_health import HealthStatus
 from igloo_mcp.profile_utils import ProfileValidationError
@@ -128,6 +134,10 @@ class SummaryStub:
         self.current_profile = "DEFAULT"
         self.profile_count = 1
         self.current_profile_authenticator = "externalbrowser"
+
+
+def _patch_reports_root(monkeypatch: pytest.MonkeyPatch, reports_root: Path) -> None:
+    monkeypatch.setattr("igloo_mcp.path_utils.resolve_reports_root", lambda *args, **kwargs: reports_root)
 
 
 @pytest.mark.asyncio
@@ -342,6 +352,161 @@ async def test_health_check_includes_query_circuit_breaker_status() -> None:
     assert full["checks"]["query_circuit_breaker"] == breaker_status
     assert full["diagnostics"]["query_circuit_breaker"] == breaker_status
     assert "query_circuit_breaker" in full.get("remediation", {})
+
+
+@pytest.mark.asyncio
+async def test_health_check_reports_health_happy_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config = Config.from_env()
+    service = StubSnowflakeService()
+    reports_root = tmp_path / "reports"
+    report_service = ReportService(reports_root)
+    report_id = report_service.create_report("Healthy Report")
+    storage = report_service.global_storage.get_report_storage(report_id)
+
+    outline = storage.load_outline()
+    outline.metadata["attachments"] = [{"path": "report_files/kept.png"}]
+    storage._save_outline_atomic(outline)
+
+    report_files_dir = storage.report_dir / "report_files"
+    report_files_dir.mkdir(parents=True, exist_ok=True)
+    (report_files_dir / "kept.png").write_text("ok", encoding="utf-8")
+
+    _patch_reports_root(monkeypatch, reports_root)
+    monkeypatch.setattr(
+        "igloo_mcp.mcp.tools.health.shutil.disk_usage",
+        lambda _path: types.SimpleNamespace(total=1000, free=600),
+    )
+
+    tool = HealthCheckTool(
+        config=config,
+        snowflake_service=service,
+    )
+
+    minimal = await tool.execute(
+        response_mode="minimal",
+        include_profile=False,
+        include_cortex=False,
+        include_catalog=False,
+        include_reports_health=True,
+    )
+    assert minimal["components"]["reports"] == "healthy"
+
+    full = await tool.execute(
+        response_mode="full",
+        include_profile=False,
+        include_cortex=False,
+        include_catalog=False,
+        include_reports_health=True,
+    )
+    reports = full["checks"]["reports"]
+
+    assert full["status"] == "healthy"
+    assert reports["status"] == "healthy"
+    assert reports["initialized"] is True
+    assert reports["total_reports"] == 1
+    assert reports["index_entries"] == 1
+    assert reports["corrupted_index_lines"] == []
+    assert reports["orphaned_index_entries"] == []
+    assert reports["missing_index_entries"] == []
+    assert reports["corrupted_audit_logs"] == []
+    assert reports["orphaned_assets"] == []
+    assert reports["warnings"] == []
+    assert reports["total_audit_events"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_health_check_reports_health_detects_storage_issues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = Config.from_env()
+    service = StubSnowflakeService()
+    reports_root = tmp_path / "reports"
+    report_service = ReportService(reports_root)
+
+    indexed_report_id = report_service.create_report("Indexed Report")
+    missing_index_report_id = report_service.create_report("Missing Index Report")
+
+    indexed_storage = report_service.global_storage.get_report_storage(indexed_report_id)
+    outline = indexed_storage.load_outline()
+    outline.metadata["attachments"] = [{"path": "report_files/kept.png"}]
+    indexed_storage._save_outline_atomic(outline)
+
+    report_files_dir = indexed_storage.report_dir / "report_files"
+    report_files_dir.mkdir(parents=True, exist_ok=True)
+    (report_files_dir / "kept.png").write_text("ok", encoding="utf-8")
+    (report_files_dir / "orphan.png").write_text("orphan", encoding="utf-8")
+
+    with indexed_storage.audit_path.open("a", encoding="utf-8") as handle:
+        handle.write("{not valid json}\n")
+
+    old_backup = indexed_storage.backups_dir / "stale.bak"
+    old_backup.write_text("old backup", encoding="utf-8")
+    stale_timestamp = (datetime.now(UTC) - timedelta(days=HealthCheckTool.REPORT_BACKUP_RETENTION_DAYS + 5)).timestamp()
+    os.utime(old_backup, (stale_timestamp, stale_timestamp))
+
+    orphan_report_id = str(uuid.uuid4())
+    index_entries = [
+        IndexEntry(
+            report_id=indexed_report_id,
+            current_title="Indexed Report",
+            created_at=datetime.now(UTC).isoformat(),
+            updated_at=datetime.now(UTC).isoformat(),
+            tags=[],
+            status="active",
+            path=f"by_id/{indexed_report_id}",
+        ),
+        IndexEntry(
+            report_id=orphan_report_id,
+            current_title="Orphaned Entry",
+            created_at=datetime.now(UTC).isoformat(),
+            updated_at=datetime.now(UTC).isoformat(),
+            tags=[],
+            status="active",
+            path=f"by_id/{orphan_report_id}",
+        ),
+    ]
+    index_path = reports_root / "index.jsonl"
+    with index_path.open("w", encoding="utf-8") as handle:
+        for entry in index_entries:
+            handle.write(json.dumps(entry.model_dump()) + "\n")
+        handle.write("{broken index line}\n")
+
+    _patch_reports_root(monkeypatch, reports_root)
+    monkeypatch.setattr(
+        "igloo_mcp.mcp.tools.health.shutil.disk_usage",
+        lambda _path: types.SimpleNamespace(total=1000, free=40),
+    )
+
+    tool = HealthCheckTool(
+        config=config,
+        snowflake_service=service,
+    )
+
+    result = await tool.execute(
+        response_mode="full",
+        include_profile=False,
+        include_cortex=False,
+        include_catalog=False,
+        include_reports_health=True,
+    )
+    reports = result["checks"]["reports"]
+
+    assert result["status"] == "unhealthy"
+    assert reports["status"] == "unhealthy"
+    assert reports["total_reports"] == 2
+    assert reports["index_entries"] == 2
+    assert len(reports["corrupted_index_lines"]) == 1
+    assert reports["orphaned_index_entries"] == [orphan_report_id]
+    assert reports["missing_index_entries"] == [missing_index_report_id]
+    assert len(reports["corrupted_audit_logs"]) == 1
+    assert reports["corrupted_audit_logs"][0]["report_id"] == indexed_report_id
+    assert reports["orphaned_assets"] == [f"{indexed_report_id}/report_files/orphan.png"]
+    assert reports["old_backups"][0]["path"] == f"{indexed_report_id}/backups/stale.bak"
+    assert reports["disk_usage"]["used_percent"] == 96.0
+    assert any("orphaned report asset" in warning for warning in reports["warnings"])
+    assert any("backup file" in warning for warning in reports["warnings"])
+    assert any("Disk usage" in warning for warning in reports["warnings"])
+    assert "reports" in result.get("remediation", {})
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -345,6 +345,7 @@ async def test_health_check_wrapper_passes_response_controls(monkeypatch: pytest
         include_cortex=False,
         include_profile=False,
         include_catalog=True,
+        include_reports_health=True,
     )
 
     kwargs = mocks["health_check"].await_args.kwargs
@@ -353,6 +354,7 @@ async def test_health_check_wrapper_passes_response_controls(monkeypatch: pytest
     assert kwargs["include_cortex"] is False
     assert kwargs["include_profile"] is False
     assert kwargs["include_catalog"] is True
+    assert kwargs["include_reports_health"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -230,13 +230,14 @@ def test_health_check_schema(base_config: Config) -> None:
     _validate_schema(schema)
 
     props = schema["properties"]
-    for flag in ("include_cortex", "include_profile", "include_catalog"):
+    for flag in ("include_cortex", "include_profile", "include_catalog", "include_reports_health"):
         flag_schema = props[flag]
         assert flag_schema["type"] == "boolean"
 
     assert props["include_cortex"]["default"] is True
     assert props["include_profile"]["default"] is True
     assert props["include_catalog"]["default"] is False
+    assert props["include_reports_health"]["default"] is False
 
     assert tool.category == "diagnostics"
     assert {"health", "profile"}.issubset(set(tool.tags))


### PR DESCRIPTION
## Summary
- add `include_reports_health` to the `health_check` MCP wrapper and tool schema
- audit Living Reports storage in read-only mode for index integrity, audit log corruption, orphaned assets, stale backups, and disk pressure
- document the new reports diagnostics and cover the happy-path and failure-path behavior with targeted tests

## Verification
- `uv run ruff check src/igloo_mcp/mcp/tools/health.py src/igloo_mcp/mcp_server.py tests/test_health_check_tool.py tests/test_mcp_server.py tests/test_tool_schemas.py`
- `uv run pytest tests/test_health_check_tool.py -q`
- `uv run pytest tests/test_mcp_server.py tests/test_tool_schemas.py -q`
- `uv run mypy src/igloo_mcp/mcp/tools/health.py src/igloo_mcp/mcp_server.py --ignore-missing-imports`

Closes #152
