### PR TITLE
chore: cut 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-03-22
+
+### Health Check Follow-up
+
+### ✨ Added
+
+- Added optional `include_reports_health` support to `health_check` so Living Reports storage can be audited alongside connection, profile, and catalog diagnostics.
+- Added read-only reports health diagnostics for index integrity, audit log corruption, orphaned `report_files/` assets, stale backups, and disk-pressure warnings.
+
+### 📝 Documentation
+
+- Documented the new `checks.reports` payload fields and example response in the `health_check` tool reference.
+
+### 🧪 Testing
+
+- Added targeted coverage for healthy and degraded Living Reports storage scenarios plus wrapper/schema assertions for the new health flag.
+
 ## [0.5.0] - 2026-03-15
 
 ### Provider Auth and Release Hardening

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "igloo_mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "Igloo MCP - Snowflake MCP Server for agentic native workflows"
 readme = "README.md"
 authors = [

--- a/src/igloo_mcp/__init__.py
+++ b/src/igloo_mcp/__init__.py
@@ -5,7 +5,7 @@ from .config import Config, get_config, set_config
 from .parallel import ParallelQueryConfig, ParallelQueryExecutor, query_multiple_objects
 from .snow_cli import SnowCLI
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = [
     "Config",
     "ParallelQueryConfig",


### PR DESCRIPTION
## Summary
- bump the package version from `0.5.0` to `0.5.1`
- add the `0.5.1` changelog entry for the Living Reports health-check follow-up
- prepare the next patch release so the existing auto-release + PyPI workflows can run from `main`

## Verification
- `uv build`
- `uv run python -c "import igloo_mcp; print(igloo_mcp.__version__)"`
